### PR TITLE
Fix escaping in JAVA_OPTS line

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
 - name: Add java agent to Tomcat Java opts
   lineinfile:
     dest: "{{ java_agent_env_path }}"
-    line: JAVA_OPTS='"${JAVA_OPTS} -javaagent:{{ java_agent_downloads_path }}/newrelic/newrelic.jar"'
+    line: 'JAVA_OPTS="${JAVA_OPTS} -javaagent:{{ java_agent_downloads_path }}/newrelic/newrelic.jar"'
   notify: restart tomcat
   tags:
     - new-relic


### PR DESCRIPTION
In 1cf1bb8 when I switched this role to a more YAML syntax I messed up the escaping of the quotation marks on the JAVA_OPTS string. This pull fixes that.